### PR TITLE
Zero initial value fix for single select mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Name  | Type (default) | Description
 ------------- | ------------- | -------------
 **parentHtmlContainer**  | HTMLElement (required!) | It should be a HTML element (div), it will be changed to the list container.
 **value**  | Array[String \| Number] ([]) | An array of `value` from `options` prop. This value will be selected on load of the treeselect. You can call `updateValue` to update prop or set value `treeselect.value` and call `mount`. The `value` changes if you check/uncheck checkboxes or remove tags from the input.
-**options**  | Array[Object] ([]) | It is an array of objects ```{name: String, value: String, disabled?: Boolean, htmlAttr?: object, children: [] }```, where children are the same array of objects. Do not use duplicated `value` field. But you can use duplicated names. [Read more](#option-description).
+**options**  | Array[Object] ([]) | It is an array of objects ```{name: String, value: String \| Number, disabled?: Boolean, htmlAttr?: object, children: [] }```, where children are the same array of objects. Do not use duplicated `value` field. But you can use duplicated names. [Read more](#option-description).
 **disabled** | Boolean (false) | List will be disabled.
 **id** | String ('') | id attribute for the accessibility.
 **ariaLabel** | String ('') | ariaLabel attribute for the accessibility.

--- a/app/examples/singleSelect.js
+++ b/app/examples/singleSelect.js
@@ -1,43 +1,43 @@
 const options = [
   {
     name: 'England',
-    value: 1,
+    value: 0,
     children: [
       {
         name: 'London',
-        value: 2,
+        value: 1,
         children: [
           {
             name: 'Chelsea',
-            value: 3,
+            value: 2,
             children: []
           },
           {
             name: 'West End',
-            value: 4,
+            value: 3,
             children: []
           }
         ]
       },
       {
         name: 'Brighton',
-        value: 5,
+        value: 4,
         children: []
       }
     ]
   },
   {
     name: 'France',
-    value: 6,
+    value: 5,
     children: [
       {
         name: 'Paris',
-        value: 7,
+        value: 6,
         children: []
       },
       {
         name: 'Lyon',
-        value: 8,
+        value: 7,
         children: []
       }
     ]
@@ -50,7 +50,7 @@ export const runSingleSelectExample = (Treeselect) => {
   const domElement = document.querySelector(className)
   const treeselect = new Treeselect({
     parentHtmlContainer: domElement,
-    value: 4,
+    value: 0,
     options: options,
     isSingleSelect: true,
     showTags: false

--- a/app/index.html
+++ b/app/index.html
@@ -192,49 +192,49 @@
           <pre class="section__props">
 <code data-language="javascript">
   <b>parentHtmlContainer:</b> document.querySelector(className),
-  <b>value:</b> 4,
+  <b>value:</b> 0,
   <b>isSingleSelect:</b> true,
   <b>showTags:</b> false,
   <b>options:</b> [
     {
       name: 'England',
-      value: 1,
+      value: 0,
       children: [
         {
           name: 'London',
-          value: 2,
+          value: 1,
           children: [
             {
               name: 'Chelsea',
-              value: 3,
+              value: 2,
               children: [],
             },
             {
               name: 'West End',
-              value: 4,
+              value: 3,
               children: []
             }
           ]
         },
         {
           name: 'Brighton',
-          value: 5,
+          value: 4,
           children: []
         }
       ]
     },
     {
       name: 'France',
-      value: 6,
+      value: 5,
       children: [
         {
           name: 'Paris',
-          value: 7,
+          value: 6,
           children: []
         },
         {
           name: 'Lyon',
-          value: 8,
+          value: 7,
           children: []
         }
       ]

--- a/src/treeselectjs.ts
+++ b/src/treeselectjs.ts
@@ -58,7 +58,7 @@ const validateProps = ({
 const getOnlyIds = (nodes: FlattedOptionType[]) => nodes.map((node) => node.id)
 
 const getDefaultValue = (value: ValueInputType) => {
-  if (!value) {
+  if (value === undefined || value === null) {
     return []
   }
 


### PR DESCRIPTION
Fixes an issue in `getDefaultValue` where the select wasn't displaying the option with the initial value of `0` (zero) when in single select mode.
Based on the types and the documentation, `0` should be a valid value for `ValueOptionType`.

Also updated the documentation (added `String | Number` to `options.value`) and slightly changed the single select example so it preselects the first option with `value: 0`.

